### PR TITLE
UI for 'My events' page + nav bar fix 

### DIFF
--- a/app/src/main/java/com/example/simplesync/ui/components/BottomNavBar.kt
+++ b/app/src/main/java/com/example/simplesync/ui/components/BottomNavBar.kt
@@ -23,7 +23,7 @@ fun BottomNavBar(navController: SimpleSyncNavController) {
                 )
             },
             selected = false,
-            onClick = { navController.bottomButtonNav(navController.CALENDAR) }
+            onClick = { navController.bottomButtonNav(navController.EVENTS) }
         )
 
         NavigationBarItem(
@@ -59,7 +59,7 @@ fun BottomNavBar(navController: SimpleSyncNavController) {
                 )
             },
             selected = false,
-            onClick = { navController.bottomButtonNav(navController.EVENTS) }
+            onClick = { navController.bottomButtonNav(navController.NOTIFICATIONS) }
         )
 
         NavigationBarItem(

--- a/app/src/main/java/com/example/simplesync/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/example/simplesync/ui/navigation/Navigation.kt
@@ -24,6 +24,7 @@ import com.example.simplesync.ui.pages.SignIn
 import com.example.simplesync.ui.pages.SignUp
 import com.example.simplesync.ui.pages.UserProfile
 import com.example.simplesync.ui.pages.FriendsPage
+import com.example.simplesync.ui.pages.NotificationsPage
 
 /*
     The purpose of this function is to collect nav into a single, easy-to-use file,
@@ -114,6 +115,9 @@ fun SimpleSyncAppNav(
         composable(navController.FRIENDS) {
             FriendsPage(navController)
         }
+        composable(navController.NOTIFICATIONS) {
+            NotificationsPage(navController)
+        }
     }
 }
 
@@ -139,6 +143,7 @@ class SimpleSyncNavController(
     val PAGE_TO_GO_TO = "PAGE_TO_GO_TO"
     val EXTERNAL_SIGN_IN = "EXTERNAL_SIGN_IN"
     val FRIENDS = "FRIENDS"
+    val NOTIFICATIONS = "NOTIFICATIONS"
 
     // and, for convenience, we also save the current page!
     // This is a kotlin class instead of a composable, so no need for statefulness

--- a/app/src/main/java/com/example/simplesync/ui/pages/Events.kt
+++ b/app/src/main/java/com/example/simplesync/ui/pages/Events.kt
@@ -1,7 +1,15 @@
 package com.example.simplesync.ui.pages
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.simplesync.ui.components.BottomNavBar
+import com.example.simplesync.ui.components.ScreenTitle
 import com.example.simplesync.ui.navigation.SimpleSyncNavController
 
 @Composable
@@ -9,4 +17,18 @@ fun EventPage(navController: SimpleSyncNavController) {
     Text(
         text = "Event Page"
     )
+
+    Scaffold(
+        bottomBar = { BottomNavBar(navController) }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+            // Title
+            ScreenTitle("My events")
+        }
+    }
 }

--- a/app/src/main/java/com/example/simplesync/ui/pages/Events.kt
+++ b/app/src/main/java/com/example/simplesync/ui/pages/Events.kt
@@ -1,21 +1,67 @@
 package com.example.simplesync.ui.pages
-
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.background
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.simplesync.ui.components.BottomNavBar
 import com.example.simplesync.ui.components.ScreenTitle
 import com.example.simplesync.ui.navigation.SimpleSyncNavController
+import com.example.simplesync.model.Event
+import com.example.simplesync.model.Visibility
+import com.example.simplesync.model.Recurrence
+import com.example.simplesync.model.*
+import kotlinx.datetime.Instant
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
+// Citation: built with ChatGPT 4o
 @Composable
 fun EventPage(navController: SimpleSyncNavController) {
-    Text(
-        text = "Event Page"
+    var searchQuery by remember { mutableStateOf("") }
+
+    // Sample data
+    val sampleEvents = listOf(
+        Event(
+            owner = "alexj",
+            name = "Guild Raid Planning",
+            description = "Sync availability for weekend event",
+            startTime = Instant.parse("2025-08-01T15:30:00Z"),
+            endTime = Instant.parse("2025-08-01T17:00:00Z"),
+            type = EventType.VIRTUAL,
+            location = "Discord",
+            recurrence = Recurrence.ONCE,
+            visibility = Visibility.PRIVATE
+        ),
+        Event(
+            owner = "marial",
+            name = "Study Group",
+            description = "Weekly meeting for study sync",
+            startTime = Instant.parse("2025-07-09T09:30:00Z"),
+            endTime = Instant.parse("2025-07-09T12:00:00Z"),
+            type = EventType.IRL,
+            location = "Library",
+            recurrence = Recurrence.WEEKLY,
+            visibility = Visibility.PUBLIC
+        )
     )
 
     Scaffold(
@@ -29,6 +75,73 @@ fun EventPage(navController: SimpleSyncNavController) {
         ) {
             // Title
             ScreenTitle("My events")
+
+            SearchBar(searchQuery, onQueryChange = { searchQuery = it })
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Filter search based on event name or location
+            val filteredEvents = sampleEvents.filter {
+                it.name.contains(searchQuery, ignoreCase = true) ||
+                        (it.location?.contains(searchQuery, ignoreCase = true) ?: false)
+            }
+                .sortedBy { it.startTime }
+
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                items(filteredEvents) { event ->
+                    EventCard(event)
+                }
+            }
         }
+    }
+}
+
+// Citation: built with ChatGPT 4o
+@Composable
+fun EventCard(event: Event) {
+    val formatter = SimpleDateFormat("MMM dd, yyyy h:mm a", Locale.getDefault())
+    val formattedDate = formatter.format(Date(event.startTime.toEpochMilliseconds()))
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(160.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.LightGray)
+    ) {
+        // Date badge
+        Text(
+            text = formattedDate,
+            color = Color.White,
+            fontSize = 14.sp,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(8.dp)
+                .background(Color.DarkGray, RoundedCornerShape(12.dp))
+                .padding(horizontal = 12.dp, vertical = 4.dp)
+        )
+
+        // Event name and owner
+        Column(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(start = 16.dp)
+        ) {
+            Text(text = event.name, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+            event.location?.let {
+                Text(text = it, fontSize = 14.sp)
+            }
+        }
+
+        // Bottom-right person icon
+        Icon(
+            imageVector = Icons.Default.Person,
+            contentDescription = "Event Owner",
+            tint = Color.Black,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(8.dp)
+                .size(24.dp)
+        )
     }
 }

--- a/app/src/main/java/com/example/simplesync/ui/pages/Notifications.kt
+++ b/app/src/main/java/com/example/simplesync/ui/pages/Notifications.kt
@@ -1,0 +1,12 @@
+package com.example.simplesync.ui.pages
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.example.simplesync.ui.navigation.SimpleSyncNavController
+
+@Composable
+fun NotificationsPage(navController: SimpleSyncNavController) {
+    Text(
+        text = "Notifications Page"
+    )
+}


### PR DESCRIPTION
Changed nav bar so that it goes to EVENTS page (instead of CALENDAR) and added route to NOTIFICATIONS 

My Events page notes
- Sample events shown with event cards, shown in order of most upcoming 
- Search bar filters by event name or by event location 

TO DO
- What to do if event date is past current date? Not show it? Make a tab to be able to see previous events? 
- When clicking on page, need to lead to event details 
- Connect profile photo to the users 
- Connect to backend events 