### PR TITLE
Fetch Google Calendar Events to Supabase

### DIFF
--- a/TimeLog
+++ b/TimeLog
@@ -5,8 +5,12 @@
 | 2025/06/07 | ------- | ---- | ------- | ------- | 1 hour  | ----- | -----
 | 2025/06/08 | 4 hours | ---- | ------- | ------- | ------  | ----- | Built Basic Scaffold
 | 2025/06/15 | ------- | ---- | ------- | 1 hour  | ------  | ----- | Helped Keegan w/ Supabase setup + ER diagrams
+| 2025/06/15 | ------- | ---- | 4 hours | ------- | ------  | ----- | Create external sign in page, and applicable buttons to profile page
 | 2025/06/16 | ------- | ---- | ------- | 3 hours | ------  | ----- | Reviewed/tested User Profile UI PR + integrated w/ backend DB
+| 2025/06/16 | ------- | ---- | 2 hours | ------- | ------  | ----- | Integrate with existing navcontroller/scaffolding
+| 2025/06/22 | ------- | ---- | 4 hours | ------- | ------  | ----- | Set up Google oauth (Google Cloud), sign in button works for gmail accounts
 | 2025/06/22 | 8 hours | ---- | ------- | ------- | ------  | ----- | Began work on Calendar
+| 2025/06/24 | ------- | ---- | 1 hour  | ------- | ------  | ----- | Open phone file explorer
 | 2025/07/03 | 6 hours | ---- | ------- | ------- | ------  | ----- | Finished Calendar Component
 | 2025/07/06 | ------- | ---- | ------- | 3 hours | ------  | ----- | Integrated Friends UI w/ backend DB
 | 2025/07/07 | ------- | ---- | ------- | 1 hour  | ------  | ----- | Looked into Event Details policy issue
@@ -17,4 +21,6 @@
 | 2025/07/14 | ------- | ---- | ------- | ------- | 4 hour  | ----- | Implement Adding friends, bunch of reworking
 | 2025/07/16 | ------- | ---- | ------- | ------- | 5 hour  | ----- | Accept/Deny, Friend PFPs, Searchbar, Delete Friends
 | 2025/07/17 | ------- | ---- | ------- | 1 hour  | ------  | ----- | Reviewed/tested Implement Friends PR
+| 2025/07/18 | ------- | ---- | 6 hours | ------- | ------  | ----- | Set up perpetual login and signout, fix active session (signed in) detection
 | 2025/07/20 | ------- | ---- | ------- | 2 hours | ------  | ----- | Implement descriptive error messages
+| 2025/07/21 | ------- | ---- | 6 hours | ------- | ------  | ----- | Implement Google Cal API events

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
 
     // oauth services
     implementation("com.google.android.gms:play-services-auth:21.0.0")
+    implementation ("com.squareup.okhttp3:okhttp:4.11.0")
+    implementation ("androidx.compose.runtime:runtime-livedata:1.6.0")
+    implementation ("com.google.code.gson:gson:2.10.1")
 
     // hilt
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/example/simplesync/model/Event.kt
+++ b/app/src/main/java/com/example/simplesync/model/Event.kt
@@ -19,6 +19,7 @@ data class Event(
     @SerialName("location") val location: String?,
     @SerialName("recurrence") val recurrence: Recurrence,
     @SerialName("visibility") val visibility: Visibility,
+    @SerialName("external_id") val externalId: String? = null,
     @Contextual @SerialName("created_at") val createdAt: Instant = Clock.System.now(),
     @Contextual @SerialName("updated_at") val updatedAt: Instant = Clock.System.now()
 )

--- a/app/src/main/java/com/example/simplesync/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/example/simplesync/viewmodel/EventViewModel.kt
@@ -1,9 +1,15 @@
 package com.example.simplesync.viewmodel
 
+import com.example.simplesync.model.Event
+import kotlinx.datetime.Instant
+import com.example.simplesync.model.EventType
+import com.example.simplesync.model.Recurrence
+import com.example.simplesync.model.Visibility
+import com.example.simplesync.viewmodel.CalendarEvent
+
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.simplesync.model.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
@@ -12,7 +18,31 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+
+
 const val EVENTS_TABLE = "events"
+
+// converts a CalendarEvent (from Google Calendar API) to our app's Event model.
+fun CalendarEvent.toAppEvent(ownerId: String): Event? {
+    val startDateTimeStr = this.start?.dateTime ?: return null
+    val endDateTimeStr = this.end?.dateTime ?: return null
+
+    val startTime = try { Instant.parse(startDateTimeStr) } catch (e: Exception) { return null }
+    val endTime = try { Instant.parse(endDateTimeStr) } catch (e: Exception) { return null }
+
+    return Event(
+        owner = ownerId,
+        name = this.summary ?: "(No title)",
+        description = this.description,
+        startTime = startTime,
+        endTime = endTime,
+        type = EventType.VIRTUAL,
+        location = this.location,
+        recurrence = Recurrence.ONCE,
+        visibility = Visibility.PUBLIC,
+        externalId = this.id
+    )
+}
 
 @HiltViewModel
 class EventViewModel @Inject constructor(
@@ -74,6 +104,11 @@ class EventViewModel @Inject constructor(
                 _eventResult.value = Result.failure(e)
             }
         }
+    }
+
+    fun isDuplicateEvent(externalId: String?): Boolean {
+        if (externalId == null) return false;
+        return _events.value.any{it.externalId == externalId}
     }
 
     // Update an existing event's fields

--- a/app/src/main/java/com/example/simplesync/viewmodel/ExternalCalendarViewModel.kt
+++ b/app/src/main/java/com/example/simplesync/viewmodel/ExternalCalendarViewModel.kt
@@ -1,0 +1,108 @@
+package com.example.simplesync.viewmodel
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.auth.GoogleAuthUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import androidx.lifecycle.MutableLiveData
+import com.google.android.gms.auth.UserRecoverableAuthException
+import android.content.Intent
+import com.google.gson.Gson
+
+data class CalendarEventsResponse(
+    val items: List<CalendarEvent>
+)
+
+data class CalendarEvent(
+    val id: String?,
+    val summary: String?,
+    val description: String?,   // <-- add this line
+    val location: String?,
+    val start: CalendarDateTime?,
+    val end: CalendarDateTime?
+)
+
+data class CalendarDateTime(
+    val dateTime: String? = null,
+    val date: String? = null
+)
+
+class ExternalCalendarViewModel : ViewModel() {
+    val consentRequiredIntent = MutableLiveData<Intent?>()
+
+    var googleAccount = mutableStateOf<GoogleSignInAccount?>(null)
+        private set
+
+    fun setGoogleAccount(account: GoogleSignInAccount?) {
+        googleAccount.value = account
+    }
+
+    // add to list
+    fun fetchGoogleCalendarEvents(
+        context: Context,
+        onSuccess: (List<CalendarEvent>) -> Unit = {}
+    ) {
+        val account = googleAccount.value
+        if (account == null) {
+            Log.d("CalendarViewModel", "No Google account connected!")
+            return
+        }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+
+                val accountObj = account.account
+                if (accountObj == null) {
+                    Log.d("CalendarViewModel", "GoogleSignInAccount.account is null!")
+                    return@launch
+                }
+
+                val token = GoogleAuthUtil.getToken(
+                    context,
+                    accountObj,
+                    "oauth2:https://www.googleapis.com/auth/calendar.readonly"
+                )
+
+                val url = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+                val request = Request.Builder()
+                    .url(url)
+                    .addHeader("Authorization", "Bearer $token")
+                    .build()
+
+                val client = OkHttpClient()
+                val response = client.newCall(request).execute()
+                val json = response.body?.string()
+                Log.d("CalendarViewModel", "Events JSON: $json")
+                // TODO: Parse JSON and update state as needed
+
+                val eventsResponse = Gson().fromJson(json, CalendarEventsResponse::class.java)
+
+                if (eventsResponse.items.isEmpty()) {
+                    Log.d("CalendarViewModel", "No events found in calendar!")
+                } else {
+                    for (event in eventsResponse.items) {
+                        Log.d(
+                            "CalendarViewModel",
+                            "Event: id=${event.id}, summary=${event.summary}, description=${event.description}, location=${event.location}, start=${event.start?.dateTime ?: event.start?.date}, end=${event.end?.dateTime ?: event.end?.date}"
+                        )
+                    }
+                }
+                onSuccess(eventsResponse.items)
+
+            } catch (e: UserRecoverableAuthException) {
+                // Notify the UI to launch the consent intent
+                consentRequiredIntent.postValue(e.intent)
+            } catch (e: Exception) {
+                Log.e("CalendarViewModel", "Calendar fetch error", e)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
* The synced-to status will now perpetually check for cached google account
* Moved google sign in to its own ExternalCalendarViewModel so it persists across all pages (important for profilepage to use the 'Sync External' button
* 'Sync External' button calls on ExternalCalendarViewModel to fetch Google Calendar events (grabs all relevant information), then (in a loop) uses toAppEvent to convert into the app's Event class
* Added new parameter "externalId" for Event that is default to null (new row in supabase for event). All regularly made events will have it set to null. Google events take the google calendar ID of the event and sets it to externalId.
* Once converted to an "appEvent", we also check for duplicate external events by comparing externalId
* Once confirmed no duplicates, use createEvent() to add to database (now shows up on events page)