### PR TITLE
Invite friends backend

### DIFF
--- a/app/src/main/java/com/example/simplesync/model/Attendee.kt
+++ b/app/src/main/java/com/example/simplesync/model/Attendee.kt
@@ -1,0 +1,13 @@
+package com.example.simplesync.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Attendee(
+    @SerialName("event_id") val eventId: String,
+    @SerialName("user_id") val userId: String,
+    @SerialName("role") val role: EventRole,
+    @SerialName("invited_by") val invitedBy: String?,
+    @SerialName("invite_status") val inviteStatus: Status,
+)

--- a/app/src/main/java/com/example/simplesync/model/Enums.kt
+++ b/app/src/main/java/com/example/simplesync/model/Enums.kt
@@ -6,3 +6,4 @@ import kotlinx.serialization.Serializable
 @Serializable enum class Recurrence { ONCE, DAILY, WEEKLY }
 @Serializable enum class Visibility { SOLO, PRIVATE, PUBLIC }
 @Serializable enum class Status { PENDING, ACCEPTED, DECLINED }
+@Serializable enum class EventRole { OWNER, EDITOR, VIEWER }

--- a/app/src/main/java/com/example/simplesync/ui/components/DropdownField.kt
+++ b/app/src/main/java/com/example/simplesync/ui/components/DropdownField.kt
@@ -14,13 +14,13 @@ fun DropdownField(
     label: String,
     options: List<String>,
     value: String,
-    onValueChange: (String) -> Unit
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
             .padding(vertical = 2.dp)
             .height(50.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -29,7 +29,6 @@ fun DropdownField(
             text = label,
             style = MaterialTheme.typography.labelSmall.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold),
             modifier = Modifier
-                .width(100.dp)
                 .padding(end = 4.dp)
         )
 
@@ -37,8 +36,7 @@ fun DropdownField(
             OutlinedTextField(
                 value = value,
                 onValueChange = {},
-                modifier = Modifier
-                    .fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 readOnly = true,
                 singleLine = true,
                 trailingIcon = {

--- a/app/src/main/java/com/example/simplesync/ui/pages/EventDetails.kt
+++ b/app/src/main/java/com/example/simplesync/ui/pages/EventDetails.kt
@@ -1,8 +1,7 @@
 package com.example.simplesync.ui.pages
 
-import androidx.compose.foundation.BorderStroke
+import DropdownField
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,32 +9,66 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.simplesync.model.Attendee
 import com.example.simplesync.ui.components.BottomNavBar
 import com.example.simplesync.ui.navigation.SimpleSyncNavController
 import com.example.simplesync.model.Event
+import com.example.simplesync.model.EventRole
+import com.example.simplesync.model.Friendship
+import com.example.simplesync.model.Status
 import com.example.simplesync.model.UserMetadata
+import com.example.simplesync.model.Visibility
 import com.example.simplesync.ui.components.EventField
+import com.example.simplesync.ui.components.ReadOnlyProfilePicture
+import com.example.simplesync.viewmodel.EventViewModel
+import com.example.simplesync.viewmodel.FriendshipViewModel
 import com.example.simplesync.viewmodel.UserViewModel
+import kotlin.collections.set
 
 // Citation: built with ChatGPT 4o
 @Composable
 fun EventDetailsPage(navController: SimpleSyncNavController, event: Event) {
+    // Events
+    val eventViewModel: EventViewModel = hiltViewModel()
+
+    // User
     val userViewModel: UserViewModel = hiltViewModel()
+    val currUser by userViewModel.currUser.collectAsState()
+    val userId = currUser?.authUser?.id
     var metadata by remember { mutableStateOf<UserMetadata?>(null) }
+
+    // Friends
+    val friendshipViewModel: FriendshipViewModel = hiltViewModel()
+    val friendsCache = remember { mutableStateMapOf<String, UserMetadata?>() }
+
+    // Attendees
+    val attendees by eventViewModel.attendeesForEvent.collectAsState()
+    val accepted = attendees.filter { it.inviteStatus == Status.ACCEPTED }
+    val pending = attendees.filter { it.inviteStatus == Status.PENDING }
+
+    // Fill your availability
     var noteText by remember { mutableStateOf("") }
 
-    LaunchedEffect(event.owner) {
-        userViewModel.fetchUserMetadataById(event.owner) {
-            metadata = it
+    LaunchedEffect(event.owner, event.id) {
+        if (currUser == null) {
+            // Don't do anything yet; wait until it's settled
+            return@LaunchedEffect
+        }
+
+        if (userId != null) {
+            userViewModel.fetchUserMetadataById(userId) { metadata = it }
+            friendshipViewModel.fetchFriendshipsForUser(userId)
+            eventViewModel.fetchAttendeesForEvent(event.id)
         }
     }
 
@@ -71,6 +104,105 @@ fun EventDetailsPage(navController: SimpleSyncNavController, event: Event) {
             HorizontalDivider()
             Spacer(modifier = Modifier.height(8.dp))
 
+            // Invite Friends Button
+            val openInviteDialog = remember { mutableStateOf(false) }
+            Button(
+                onClick = { openInviteDialog.value = true },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Invite Friends to This Event")
+            }
+            // Invite Friends Popup Dialog
+            if (openInviteDialog.value) {
+                AlertDialog(
+                    onDismissRequest = { openInviteDialog.value = false },
+                    title = { Text("Invite Friends") },
+                    confirmButton = {
+                        TextButton(onClick = { openInviteDialog.value = false }) {
+                            Text("Close")
+                        }
+                    },
+                    text = {
+                        InviteDialogContent(
+                            event = event,
+                            userId = userId ?: "",
+                            eventViewModel = eventViewModel,
+                            userViewModel = userViewModel,
+                            friendshipViewModel = friendshipViewModel,
+                            friendsCache = friendsCache
+                        )
+                    }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Participants
+            Text("Participants", fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(4.dp))
+            if (accepted.isEmpty()) {
+                Text("No participants yet.")
+            } else {
+                accepted.forEach { attendee ->
+                    if (!friendsCache.containsKey(attendee.userId)) {
+                        LaunchedEffect(attendee.userId) { // Add to cache if not already present
+                            val fetched = userViewModel.getUserById(attendee.userId)
+                            friendsCache[attendee.userId] = fetched
+                        }
+                    }
+
+                    val user = friendsCache[attendee.userId]
+                    if (user != null) {
+                        AttendeeListItem(
+                            metadata = user,
+                            role = attendee.role,
+                            showDeleteButton = event.owner == userId && attendee.userId != userId,
+                            onDelete = {
+                                // Call delete from eventViewModel
+                                eventViewModel.removeAttendee(event.id, attendee.userId)
+                            }
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Pending Invitations
+            Text("Pending Invitations", fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(4.dp))
+            if (pending.isEmpty()) {
+                Text("No pending invites.")
+            } else {
+                pending.forEach { attendee ->
+                    if (!friendsCache.containsKey(attendee.userId)) {
+                        LaunchedEffect(attendee.userId) { // Add to cache if not already present
+                            val fetched = userViewModel.getUserById(attendee.userId)
+                            friendsCache[attendee.userId] = fetched
+                        }
+                    }
+                    val user = friendsCache[attendee.userId]
+
+                    if (user != null) {
+                        AttendeeListItem(
+                            metadata = user,
+                            role = attendee.role,
+                            showDeleteButton = event.owner == userId,
+                            onDelete = {
+                                // Call delete from eventViewModel
+                                eventViewModel.removeAttendee(event.id, attendee.userId)
+                            }
+                        )
+                    }
+                }
+            }
+
+
+            // Fill your availability
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -164,6 +296,239 @@ fun DetailRow(label: String, value: String) {
         }
     }
 }
+
+@Composable
+fun InviteDialogContent(
+    event: Event,
+    userId: String,
+    eventViewModel: EventViewModel,
+    userViewModel: UserViewModel,
+    friendshipViewModel: FriendshipViewModel,
+    friendsCache: MutableMap<String, UserMetadata?>
+) {
+    val attendees by eventViewModel.attendeesForEvent.collectAsState()
+    val friendships by friendshipViewModel.friendships.collectAsState()
+
+    // Invite Section
+    InviteFriendsSection(
+        userId = userId,
+        event = event,
+        friendships = friendships,
+        friendsCache = friendsCache,
+        userViewModel = userViewModel,
+        eventViewModel = eventViewModel,
+        attendees = attendees,
+    )
+
+}
+
+
+@Composable
+fun InviteFriendsSection(
+    userId: String,
+    event: Event,
+    friendships: List<Friendship>,
+    friendsCache: MutableMap<String, UserMetadata?>,
+    userViewModel: UserViewModel,
+    eventViewModel: EventViewModel,
+    attendees: List<Attendee>
+) {
+    val invitedUsers = remember { mutableStateListOf<String>() }
+
+    // Skip friends who are already invited (pending) or accepted
+    val alreadyInvolvedIds = attendees.map { it.userId }.toSet()
+    val inviteableFriendships = friendships
+        .filter { it.status == Status.ACCEPTED }
+        .filter {
+            val friendId = if (it.userId == userId) it.friendId else it.userId
+            !alreadyInvolvedIds.contains(friendId)
+        }
+
+    if (event.visibility != Visibility.SOLO && friendships.isNotEmpty()) {
+        // At least 1 friend to invite
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 400.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = 4.dp)
+        ) {
+            inviteableFriendships.forEach { friendship ->
+                val otherUserId =
+                    if (friendship.userId == userId) friendship.friendId else friendship.userId
+                if (!friendsCache.containsKey(otherUserId)) {
+                    LaunchedEffect(otherUserId) { // Add to cache if not already present
+                        val fetched = userViewModel.getUserById(otherUserId)
+                        friendsCache[otherUserId] = fetched
+                    }
+                }
+                val friend = friendsCache[otherUserId]
+
+                if (friend != null) {
+                    InviteFriendsItem(
+                        friendMetadata = friend,
+                        alreadyInvited = invitedUsers.contains(friend.id),
+                        onInvite = {
+                            eventViewModel.inviteUserToEvent(
+                                eventId = event.id,
+                                toUser = friend.id,
+                                fromUser = userId,
+                                role = EventRole.EDITOR,
+                            )
+                            invitedUsers.add(friend.id)
+                        }
+                    )
+                }
+            }
+        }
+    } else if (event.visibility != Visibility.SOLO && friendships.isEmpty()) {
+        // No friends to invite
+        Text(
+            text = "No friends found.",
+            color = Color.Gray,
+            fontSize = 14.sp,
+        )
+    }
+}
+
+@Composable
+fun InviteFriendsItem(
+    friendMetadata: UserMetadata,
+    alreadyInvited: Boolean = false,
+    onInvite: (EventRole) -> Unit
+) {
+    val roles = listOf("Owner", "Editor", "Viewer")
+    var selectedRole by remember { mutableStateOf(EventRole.EDITOR) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp)
+    ) {
+        // --- Row 1: Profile + Name + Username ---
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            // Profile
+            if (!friendMetadata.profilePicURL.isNullOrEmpty()) {
+                ReadOnlyProfilePicture(
+                    imageUrl = friendMetadata.profilePicURL,
+                    size = 48.dp,
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Default.Person,
+                    contentDescription = "Profile",
+                    modifier = Modifier
+                        .size(48.dp)
+                        .padding(end = 8.dp)
+                )
+            }
+
+            // Name + Username
+            Column(modifier = Modifier.padding(start = 8.dp)) {
+                Text(
+                    text = "${friendMetadata.firstName} ${friendMetadata.lastName}",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp
+                )
+                Text(
+                    text = "@${friendMetadata.username}",
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // --- Row 2: Role dropdown + Invite button ---
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            DropdownField(
+                label = "Role:",
+                options = roles,
+                value = selectedRole.name.lowercase().replaceFirstChar { it.uppercase() },
+                onValueChange = { selectedDisplay ->
+                    selectedRole = EventRole.valueOf(selectedDisplay.uppercase())
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 8.dp)
+            )
+
+            Button(
+                onClick = { onInvite(selectedRole) },
+                enabled = !alreadyInvited,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (alreadyInvited) Color.Gray else Color.DarkGray
+                ),
+                modifier = Modifier.height(48.dp)
+            ) {
+                Text(if (alreadyInvited) "Invited" else "Invite", color = Color.White)
+            }
+        }
+    }
+}
+
+@Composable
+fun AttendeeListItem(
+    metadata: UserMetadata,
+    role: EventRole,
+    showDeleteButton: Boolean = false,
+    onDelete: (() -> Unit)? = null
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Profile picture
+        if (!metadata.profilePicURL.isNullOrEmpty()) {
+            ReadOnlyProfilePicture(imageUrl = metadata.profilePicURL, size = 48.dp)
+        } else {
+            Icon(
+                imageVector = Icons.Default.Person,
+                contentDescription = "Profile",
+                modifier = Modifier
+                    .size(48.dp)
+                    .padding(end = 8.dp)
+            )
+        }
+
+        // Name + Role
+        Column(modifier = Modifier
+            .weight(1f)
+            .padding(start = 8.dp)) {
+            Text(
+                text = "${metadata.firstName} ${metadata.lastName}",
+                fontWeight = FontWeight.Bold,
+                fontSize = 16.sp
+            )
+            Text(
+                text = "Role: ${role.name.lowercase().replaceFirstChar { it.uppercase() }}",
+                fontSize = 13.sp,
+                color = Color.Gray
+            )
+        }
+
+        // Delete button
+        if (showDeleteButton && onDelete != null) {
+            IconButton(onClick = onDelete) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Remove attendee",
+                    tint = Color.Red
+                )
+            }
+        }
+    }
+}
+
 
 // Citation: from Chat GPT 4o
 fun formatEventTime(event: Event): String {

--- a/app/src/main/java/com/example/simplesync/ui/pages/NewEvent.kt
+++ b/app/src/main/java/com/example/simplesync/ui/pages/NewEvent.kt
@@ -1,6 +1,7 @@
 package com.example.simplesync.ui.pages
 
 import DropdownField
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
@@ -57,16 +58,17 @@ fun NewEventPage(
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // Popup for event creation results
-    LaunchedEffect (createEventResult) {
-        createEventResult?.let {
-            it.onSuccess {
+    // Handle createEventResult
+    LaunchedEffect(createEventResult) {
+        createEventResult?.let { result ->
+            result.onSuccess { event ->
                 coroutineScope.launch {
                     snackbarHostState.showSnackbar("Successfully created event!")
                 }
-                navController.nav(navController.EVENTS) // TODO: Update to navigate to the created event's page
+                // Navigate using the actual event
+                navController.nav(navController.eventDetailsRoute(event.id))
             }.onFailure { e ->
-                print("ERROR: ${e.message}")
+                Log.e("NewEventPage", "Event creation failed", e)
                 coroutineScope.launch {
                     snackbarHostState.showSnackbar("Error: ${e.message}")
                 }
@@ -132,15 +134,11 @@ fun NewEventPage(
             Spacer(modifier = Modifier.height(8.dp))
 
             // Fields that will be synced with the backend
-            EventField("Name:", name, {name = it})
-            EventField("Description:", description, {description = it})
+            EventField("Name:", name) {name = it}
+            EventField("Description:", description) {description = it}
 
-            DateTimePickerField("Start Time", startTime) {
-                startTime = it
-            }
-            DateTimePickerField("End Time", endTime) {
-                endTime = it
-            }
+            DateTimePickerField("Start Time", startTime) { startTime = it }
+            DateTimePickerField("End Time", endTime) { endTime = it }
 
             DropdownField(
                 label = "Type:",


### PR DESCRIPTION
- Navigate to the event specific page on new event creation
- Create supabase trigger function to create an attendee row corresponding to the owner of the event when the event is first created.
- Add an invite friends button to the event details page, which allows friends to be invited to the event with a role selected.
- Show participants of an event on the event details page.
- Show pending invitations 
- Allow pending invitations and participants to be deleted by event owners

TODO:
- Change Events page to display events that you have accepted invites to
- Notifications page should show pending invites to events
- Allow the editing of event fields (for owners and editors)
- There's some weird bug where the user session does not begin and thus some fields are not fetched...

<img width="348" height="741" alt="image" src="https://github.com/user-attachments/assets/a8bc21d8-492d-494d-8d75-eabc8cf1c085" />
<img width="402" height="778" alt="image" src="https://github.com/user-attachments/assets/26906cbb-6937-41f6-93ee-943d3aefe748" />

